### PR TITLE
filter Gemfile on tapp grep

### DIFF
--- a/lib/tapp/command.rb
+++ b/lib/tapp/command.rb
@@ -4,7 +4,9 @@ module Tapp
   class Command < Thor
     desc 'grep [<git-grep-options>]', 'Print lines using tapp'
     def grep(*)
-      system 'git', 'grep', '--word-regexp', '-e', 'tapp', *ARGV.drop(1)
+      opts = ['--word-regexp', '-e', 'tapp', *ARGV.drop(1)]
+      git_grep = ['git', 'grep', opts].flatten.join(" ")
+      puts `#{git_grep}`.gsub(/^Gemfile(\.lock)?:.+?\n/, '')
     end
   end
 end


### PR DESCRIPTION
I think we don't need 'Gemfile: tapp' on tapp grep result output.

here's pull request to proof of concept:

thanks,
