### PR TITLE
remove circular require

### DIFF
--- a/lib/tapp/util.rb
+++ b/lib/tapp/util.rb
@@ -1,5 +1,3 @@
-require 'tapp'
-
 module Tapp
   module Util
     module_function


### PR DESCRIPTION
I got warnings for circular require with `ruby -w`. I remove to unneeded require.
