### PR TITLE
Suppress deprecation warning from RSpec using `expect` syntax

### DIFF
--- a/spec/steps/global_steps.rb
+++ b/spec/steps/global_steps.rb
@@ -24,5 +24,5 @@ step 'Ruby it' do
 end
 
 step 'I should see:' do |output|
-  @output.should == output
+  expect(@output).to eq output
 end


### PR DESCRIPTION
Do you prefer `should` syntax, by any chance?
