### PR TITLE
Remove warning: `*' interpreted as argument prefix

### DIFF
--- a/lib/tapp/printer/pretty_print.rb
+++ b/lib/tapp/printer/pretty_print.rb
@@ -9,11 +9,11 @@ module Tapp::Printer
         remove_method :print
 
         def print(*args)
-          pp *args
+          pp(*args)
         end
       end
 
-      print *args
+      print(*args)
     end
   end
 

--- a/lib/tapp/printer/puts.rb
+++ b/lib/tapp/printer/puts.rb
@@ -3,7 +3,7 @@ require 'tapp/printer'
 module Tapp::Printer
   class Puts < Base
     def print(*args)
-      puts *args
+      puts(*args)
     end
   end
 


### PR DESCRIPTION
I fix below warnings.

```
irb(main):001:0> RUBY_VERSION
=> "2.2.1"
irb(main):002:0> $VERBOSE = true
=> true
irb(main):003:0> require 'tapp'
/Users/naiad/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/tapp-1.5.0/lib/tapp/printer/pretty_print.rb:12: warning: `*' interpreted as argument prefix
/Users/naiad/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/tapp-1.5.0/lib/tapp/printer/pretty_print.rb:16: warning: `*' interpreted as argument prefix
/Users/naiad/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/tapp-1.5.0/lib/tapp/printer/puts.rb:6: warning: `*' interpreted as argument prefix
=> true
```