### PR TITLE
Add decoration feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ See more examples in [spec/acceptance](https://github.com/esminc/tapp/tree/maste
 Tapp.configure do |config|
   config.report_caller   = true
   config.default_printer = :puts
+  config.decoration      = true
 end
 ```
 
@@ -41,6 +42,11 @@ end
     <td><code>default_printer</code></td>
     <td><code>:pretty_print</code></td>
     <td><a href="https://github.com/esminc/tapp/blob/master/spec/acceptance/default_printer.feature">default_printer.feature</a></td>
+  </tr>
+  <tr>
+    <td><code>decoration</code></td>
+    <td><code>false</code></td>
+    <td><a href="https://github.com/esminc/tapp/blob/master/spec/acceptance/tapp.feature">tapp.feature</a></td>
   </tr>
 </table>
 

--- a/lib/tapp/configuration.rb
+++ b/lib/tapp/configuration.rb
@@ -1,6 +1,6 @@
 module Tapp
   class Configuration
-    attr_accessor :default_printer, :report_caller
+    attr_accessor :default_printer, :report_caller, :decoration
 
     def initialize
       reset
@@ -9,6 +9,7 @@ module Tapp
     def reset
       self.default_printer = :pretty_print
       self.report_caller   = false
+      self.decoration      = false
     end
   end
 end

--- a/lib/tapp/object_extension.rb
+++ b/lib/tapp/object_extension.rb
@@ -9,7 +9,7 @@ module Tapp
       if Tapp.config.decoration
         require 'tapp/print_decorator'
         decorator = Tapp::PrintDecorator.instance
-        decorator.register_delegator(Tapp::Printer.instance(printer))
+        decorator.register_printer(Tapp::Printer.instance(printer))
         tap {
           decorator.print block_given? ? yield(self) : self
         }

--- a/lib/tapp/object_extension.rb
+++ b/lib/tapp/object_extension.rb
@@ -6,9 +6,18 @@ module Tapp
     def tapp(printer = Tapp.config.default_printer)
       Tapp::Util.report_called if Tapp.config.report_caller
 
-      tap {
-        Tapp::Printer.instance(printer).print block_given? ? yield(self) : self
-      }
+      if Tapp.config.decoration
+        require 'tapp/print_decorator'
+        decorator = Tapp::PrintDecorator.instance
+        decorator.register_delegator(Tapp::Printer.instance(printer))
+        tap {
+          decorator.print block_given? ? yield(self) : self
+        }
+      else
+        tap {
+          Tapp::Printer.instance(printer).print block_given? ? yield(self) : self
+        }
+      end
     end
 
     def taputs(&block)

--- a/lib/tapp/print_decorator.rb
+++ b/lib/tapp/print_decorator.rb
@@ -1,0 +1,21 @@
+require 'forwardable'
+
+module Tapp
+  class PrintDecorator
+    include Singleton
+    extend Forwardable
+
+    delegate [:print] => :@delegator
+
+    def register_delegator(delegator)
+      @delegator = delegator
+    end
+
+    def print(*args)
+      decoration = "~*" * 30
+      puts decoration
+      @delegator.print(*args)
+      puts decoration
+    end
+  end
+end

--- a/lib/tapp/print_decorator.rb
+++ b/lib/tapp/print_decorator.rb
@@ -1,20 +1,15 @@
-require 'forwardable'
-
 module Tapp
   class PrintDecorator
     include Singleton
-    extend Forwardable
 
-    delegate [:print] => :@delegator
-
-    def register_delegator(delegator)
-      @delegator = delegator
+    def register_printer(printer)
+      @printer = printer
     end
 
     def print(*args)
       decoration = "~*" * 30
       puts decoration
-      @delegator.print(*args)
+      @printer.print(*args)
       puts decoration
     end
   end

--- a/spec/acceptance/report_caller.feature
+++ b/spec/acceptance/report_caller.feature
@@ -19,3 +19,27 @@ Feature: config.report_caller
     `tapp' in hello.rb:5:in `say'
     "hello"
     """
+
+  Scenario: set config.report_caller to true and call tapp when the decoration option is provided
+    Given a file named "hello.rb" with:
+    """
+    Tapp.config.decoration = true
+    Tapp.config.report_caller = true
+
+    class Hello
+      def say
+        'hello'.tapp
+      end
+    end
+
+    Hello.new.say
+    """
+
+    When Ruby it
+    Then I should see:
+    """
+    `tapp' in hello.rb:6:in `say'
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    "hello"
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    """

--- a/spec/acceptance/tapp.feature
+++ b/spec/acceptance/tapp.feature
@@ -11,3 +11,22 @@ Feature: Object#tapp
     1..5
     [1, 3, 5]
     """
+
+  Scenario: Call tapp within methods chain when the decoration option is provided
+    Given I have the following code:
+    """
+    Tapp.config.decoration = true
+
+    (1..5).tapp.select(&:odd?).tapp.inject(&:+)
+    """
+
+    When Ruby it
+    Then I should see:
+    """
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    1..5
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    [1, 3, 5]
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    """

--- a/spec/acceptance/taputs.feature
+++ b/spec/acceptance/taputs.feature
@@ -30,3 +30,47 @@ Feature: Object#taputs
     3
     5
     """
+
+  Scenario: Call taputs within methods chain when the decoration option is provided
+    Given I have the following code:
+    """
+    Tapp.config.decoration = true
+
+    (1..5).taputs.select(&:odd?).taputs.inject(&:+)
+    """
+
+    When Ruby it
+
+    Then I should see:
+    """
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    1..5
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    1
+    3
+    5
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    """
+
+  Scenario: Call taputs with block when the decoration option is provided
+    Given I have the following code:
+    """
+    Tapp.config.decoration = true
+
+    (1..5).taputs(&:count).select(&:odd?).taputs
+    """
+
+    When Ruby it
+
+    Then I should see:
+    """
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    5
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    1
+    3
+    5
+    ~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
+    """


### PR DESCRIPTION
Since sometimes highlighting print-debugging-logs is useful for me, especially when outputting a lot of logs, to find the logs written via tapp,  I have added a decoration feature to tapp printer like the followings:

```text
some logs ...
~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
logs written by tapp
~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
some logs ...
some logs ...
some logs ...
~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
logs written by tapp
~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*
some logs ...
```

You can enable this feature by setting `Tapp.config.decoration = true`. This new feature doesn't have any effects on the existing implementation so far when you leave `Tapp.config.decoration = false`, 

At first I have created [another gem "Qtapp"](https://rubygems.org/gems/qtapp) by forking repository for personal use (it has "highline" dependency for colorizing though), but I think it will be great if tapp has this feature too.

## Modified (2015-08-20 14:12)

Fix unused "fowardable" is required.