### PR TITLE
Use the latest Rubies on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,11 @@ rvm:
   - 2.0.0
   - 2.1
   - 2.2
-  - 2.3.4
-  - 2.4.1
+  - 2.3.8
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
   - ruby-head
 
 before_install: gem update bundler

--- a/tapp.gemspec
+++ b/tapp.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'thor'
 
-  s.add_development_dependency 'turnip'
+  # Pin a Turnip version that doesn't use Ruby 2.3 safe navigation operator syntax.
+  s.add_development_dependency 'turnip', '~> 3'
 end


### PR DESCRIPTION
These Rubies has been released.

https://www.ruby-lang.org/en/news/2018/10/17/ruby-2-3-8-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-4-10-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-5-8-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-6-6-released/
https://www.ruby-lang.org/en/news/2020/03/31/ruby-2-7-1-released/